### PR TITLE
Prevent the failure of extracting darwin.iso from being overwritten by the success of extracting darwinPre15.iso

### DIFF
--- a/src/unlocker.cpp
+++ b/src/unlocker.cpp
@@ -723,7 +723,7 @@ void downloadTools(fs::path path)
 					logd("Extracting from .zip to destination folder ...");
 
 					success = Archive::extract_zip(temppath / FUSION_DEF_CORE_NAME_ZIP, FUSION_ZIP_TOOLS_ISO, path / FUSION_ZIP_TOOLS_NAME);
-					success = Archive::extract_zip(temppath / FUSION_DEF_CORE_NAME_ZIP, FUSION_ZIP_PRE15_TOOLS_ISO, path / FUSION_ZIP_PRE15_TOOLS_NAME);
+					success &= Archive::extract_zip(temppath / FUSION_DEF_CORE_NAME_ZIP, FUSION_ZIP_PRE15_TOOLS_ISO, path / FUSION_ZIP_PRE15_TOOLS_NAME);
 
 					// Cleanup zip file
 					fs::remove(temppath / FUSION_DEF_CORE_NAME_ZIP);


### PR DESCRIPTION
Hi. This "bug" seems to have existed since the birth of this project:

- https://github.com/paolo-projects/auto-unlocker/blame/d94a62890c4cbed6dc0f791abf6b270f2a64b32c/src/unlocker.cpp#L725-L726
- https://github.com/paolo-projects/auto-unlocker/blame/e877c633626b58ec9c07926eca2f153a9769cb0b/src/unlocker.cpp#L722-L723
- https://github.com/paolo-projects/auto-unlocker/blame/79ef82d9bd8f7d25127092ce850615b4e3053595/src/unlocker.cpp#L719-L720
- https://github.com/paolo-projects/auto-unlocker/blame/810044e5295f23856df66cafef800c2d8ed8bd65/src/unlocker.cpp#L702-L703

If the overwrite behavior is intentional, please close this PR.
