### PR TITLE
Include "algorithm" in /include/tar.h to use "std::min"

### DIFF
--- a/include/tar.h
+++ b/include/tar.h
@@ -5,6 +5,7 @@
 #include <vector>
 #include <stdexcept>
 #include <cmath>
+#include <algorithm>
 
 
 enum tar_type_flag {


### PR DESCRIPTION
Hi. I tried to build this project with MSVC but got some errors about `std::min` as follows:

```console
"C:\auto-unlocker\Unlocker.sln" (Unlocker target) (1) ->
"C:\auto-unlocker\Unlocker.vcxproj.metaproj" (default target) (2) ->
"C:\auto-unlocker\Unlocker.vcxproj" (default target) (4) ->
(ClCompile target) ->
  C:\auto-unlocker\src\tar.cpp(84,22): error C2039: 'min': is not a member of 'std' [C:\auto-unlocker\Unlocker.vcxproj]
  C:\auto-unlocker\src\tar.cpp(84,25): error C3861: 'min': identifier not found [C:\auto-unlocker\Unlocker.vcxproj]
```

I have no idea why you don't suffer from this problem; maybe due to the order of includes (it was included in [/include/netutils.h](https://github.com/paolo-projects/auto-unlocker/blob/d94a62890c4cbed6dc0f791abf6b270f2a64b32c/include/netutils.h#L10))? I can't also reproduce it with gcc on Ubuntu.

I don't think that including "algorithm" might break anything, so I made this PR.

Configurations:

- Windows 10 2004 10.0.19041.329
- MSVC 19.26.28806.0
- Windows SDK 10.0.18362.0
- CMake 3.20.2
- zlib 1.2.11 (built from source)
- curl 7.76.1 (built from source)
- libzip 1.7.3 (built from source)
- auto-unlocker @ d94a62890c4cbed6dc0f791abf6b270f2a64b32c
