### PR TITLE
Let CMake use "find_package" to find an available multi-threading library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,9 +72,8 @@ add_executable(Unlocker ${SOURCE_FILES} )
 
 set_target_properties(Unlocker PROPERTIES CXX_STANDARD 17 CXX_STANDARD_REQUIRED ON CXX_EXTENSIONS ON)
 
-if(LINUX)
-	target_link_libraries (Unlocker -lpthread)
-endif()
+find_package(Threads REQUIRED)
+target_link_libraries(Unlocker Threads::Threads)
 
 target_link_libraries (Unlocker ${ZLIB_LIBRARIES})
 target_link_libraries (Unlocker ${CURL_LIBRARIES})


### PR DESCRIPTION
Hi. I got a linker error when building this project on Linux:

```console
$ cmake . && make
...
[100%] Linking CXX executable Unlocker
/usr/bin/ld: CMakeFiles/Unlocker.dir/src/netutils.cpp.o: undefined reference to symbol 'pthread_create@@GLIBC_2.2.5'
/usr/bin/ld: /lib/x86_64-linux-gnu/libpthread.so.0: error adding symbols: DSO missing from command line
collect2: error: ld returned 1 exit status
make[2]: *** [CMakeFiles/Unlocker.dir/build.make:222: Unlocker] Error 1
make[1]: *** [CMakeFiles/Makefile2:105: CMakeFiles/Unlocker.dir/all] Error 2
make: *** [Makefile:95: all] Error 2
```

It seems that these is no per-defined variable `LINUX` in CMake. Otherwise, the `-lpthread` flag would be passed to the linker.

```CMake
if(LINUX)
	target_link_libraries (Unlocker -lpthread)
endif()
```

https://github.com/paolo-projects/auto-unlocker/blob/4a94606e8b71662a92ea3cb445ae2923928d9ea8/CMakeLists.txt#L75-L77

Then, I removed the `if` command and got a successful building.

After some searching, I found the following solutions:

- Replace the condition `LINUX` with `CMAKE_SYSTEM_NAME STREQUAL "Linux"` . The value of `CMAKE_SYSTEM_NAME` equals `uname -s` on Unix ([code](https://github.com/Kitware/CMake/blob/v3.1.0/Modules/CMakeDetermineSystem.cmake)).
- Use `find_package` to find multi-threading libraries instead of checking the OS type and specifying the linker flag manually. I chose this.

I tested this PR on both Ubuntu and Windows and it works fine.

If you prefer, you can add `set(THREADS_PREFER_PTHREAD_FLAG ON)` before `find_package` .

Configurations:

- auto-unlocker @ 4a94606e8b71662a92ea3cb445ae2923928d9ea8
- OS
  - Windows:
    - Windows 10 2004 10.0.19041.329
    - MSVC 19.26.28806.0
    - Windows SDK 10.0.18362.0
    - CMake 3.20.2
    - zlib 1.2.11 (built from source)
    - curl 7.76.1 (built from source)
    - libzip 1.7.3 (built from source)
  - Linux:
    - Kernel 5.8.0-50-generic
    - Ubuntu 20.04.0
    - gcc 9.3.0 (apt)
    - CMake 3.16.3 (apt)
    - zlib (zlib1g-dev) 1.2.11 (apt)
    - curl (libcurl4-openssl-dev) 7.68.0 (apt)
    - libzip (libzip-dev) 1.5.1 (apt)
