### PR TITLE
Use curl progress callback directly to avoid cluttering the console on Windows, and drop threads

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,10 +72,6 @@ add_executable(Unlocker ${SOURCE_FILES} )
 
 set_target_properties(Unlocker PROPERTIES CXX_STANDARD 17 CXX_STANDARD_REQUIRED ON CXX_EXTENSIONS ON)
 
-if(LINUX)
-	target_link_libraries (Unlocker -lpthread)
-endif()
-
 target_link_libraries (Unlocker ${ZLIB_LIBRARIES})
 target_link_libraries (Unlocker ${CURL_LIBRARIES})
 #target_link_libraries (Unlocker ${LibArchive_LIBRARIES})

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ obj	= $(src:.cpp=.o)
 INCLUDE		= -Iinclude
 CXXFLAGS	= -Wall -std=c++17 $(INCLUDE)
 
-LIBS	+= -lcurl -lzip -lpthread -lstdc++fs
+LIBS	+= -lcurl -lzip -lstdc++fs
 
 auto-unlocker:	$(obj)
 	$(CXX) $(CXXFLAGS) -o $@ $^ $(LIBS)

--- a/include/netutils.h
+++ b/include/netutils.h
@@ -8,7 +8,6 @@
 #include <iostream>
 #include <iomanip>
 #include <algorithm>
-#include <thread>
 #include <chrono>
 
 #define DEBUG false
@@ -16,7 +15,6 @@
 namespace Curl
 {
 	size_t write_data_file(char* ptr, size_t size, size_t nmemb, void* stream);
-	void updateProgress();
 	int progress_callback(void* clientp, double dltotal, double dlnow, double ultotal, double ulnow);
 	CURLcode curlDownload(std::string url, std::string fileName);
 	CURLcode curlGet(std::string url, std::string& output);

--- a/src/netutils.cpp
+++ b/src/netutils.cpp
@@ -11,28 +11,14 @@ size_t Curl::write_data_file(char* ptr, size_t size, size_t nmemb, void* stream)
 	return bytes;
 }
 
-static double dled = 0.0;
-static double dltot = 0.0;
-static bool progressrun = false;
-
-void Curl::updateProgress()
-{
-	while (progressrun)
-	{
-		if (dltot > 0)
-		{
-			double mBytesTotal = dltot / 1024 / 1024;
-			double mBytesNow = dled / 1024 / 1024;
-			std::cout << "Download progress: " << (std::min)(100, (std::max)(0, int(dled * 100 / dltot))) << " %, " << std::fixed << std::setprecision(2) << mBytesNow << " MB / " << mBytesTotal << " MB                    \r";
-		}
-		std::this_thread::sleep_for(std::chrono::seconds(1));
-	}
-}
-
 int Curl::progress_callback(void* clientp, double dltotal, double dlnow, double ultotal, double ulnow)
 {
-	dled = dlnow;
-	dltot = dltotal;
+	if (dltotal > 0)
+	{
+		double mBytesTotal = dltotal / 1024 / 1024;
+		double mBytesNow = dlnow / 1024 / 1024;
+		std::cout << "Download progress: " << (std::min)(100, (std::max)(0, int(dlnow * 100 / dltotal))) << " %, " << std::fixed << std::setprecision(2) << mBytesNow << " MB / " << mBytesTotal << " MB                    \r";
+	}
 	return 0;
 }
 
@@ -61,13 +47,7 @@ CURLcode Curl::curlDownload(std::string url, std::string fileName)
 		curl_easy_setopt(curl, CURLOPT_PROGRESSFUNCTION, progress_callback);
 		curl_easy_setopt(curl, CURLOPT_NOPROGRESS, 0);
 		/* get it! */
-		dltot = 0.0;
-		dled = 0.0;
-		progressrun = true;
-		std::thread progressthread(updateProgress);
-		progressthread.detach();
 		CURLcode res = curl_easy_perform(curl);
-		progressrun = false;
 		out_file.close();
 
 		std::cout << std::endl;

--- a/src/netutils.cpp
+++ b/src/netutils.cpp
@@ -27,7 +27,7 @@ int Curl::progress_callback(void* clientp, double dltotal, double dlnow, double 
 			return 0;
 		}
 
-		std::cout << "Download progress: " << (std::min)(100, (std::max)(0, int(dlnow * 100 / dltotal))) << " %, " << std::fixed << std::setprecision(2) << mBytesNow << " MB / " << mBytesTotal << " MB                    \r";
+		std::cout << "Download progress: " << (std::min)(100, (std::max)(0, int(dlnow * 100 / dltotal))) << " %, " << std::fixed << std::setprecision(2) << mBytesNow << " MB / " << mBytesTotal << " MB                    \r" << std::flush;
 
 		mBytesDownloadedLastTime = mBytesNow;
 	}


### PR DESCRIPTION
When using this program in CMD or PowerShell on Windows, its output sometimes becomes messy. Like this:

```console
PS > & .\Unlocker.exe --download-tools
auto-unlocker v1.1.3



Download progress: Download progress: Download progress: 2 %, 15.702 %, 16.292 %, 16.29 MB / 627.79 MB
Extracting from .tar to temp folder ...
Extracting from .zip to destination folder ...
Tools successfully downloaded!
Press enter to quit.
```

I tried `std::flush` , but it didn't solve the problem. Then I found that the original progress output of libcurl works fine on both Windows and Linux, so I realized that this may be a problem with multithreading. After simplifying the program, the output is no longer messy:

```console
PS > & .\Unlocker.exe --download-tools
auto-unlocker v1.1.3



Download progress: 5 %, 36.00 MB / 627.79 MB
```

```console
$ ./auto-unlocker --download-tools
auto-unlocker v1.1.3

The program is not running as root, the patch may not work properly.
Running the program with sudo/as root is recommended, in most cases required... Do you want to continue? (y/N) y


Download progress: 62 %, 390.68 MB / 627.79 MB
```

Since the beginning of this project ( https://github.com/paolo-projects/auto-unlocker/commit/811cd9f0e276453b877d941db329ecb0f0de503c#diff-9c936435ee95249f5cdc003b224042dd6b42660ffdc813d569d67758a890c633 ), you have been using another thread to output the progress. I'm curious about the reason for this, so it would be great if you could provide some explanation.

Since I removed the only part of this program which uses `<thread>` , I removed everything about threads as well.

We should close #50 if this PR is merged.

Configurations:

- auto-unlocker @ 4a94606e8b71662a92ea3cb445ae2923928d9ea8
- OS
  - Windows:
    - Windows 10 2004 10.0.19041.329
    - MSVC 19.26.28806.0
    - Windows SDK 10.0.18362.0
    - CMake 3.20.2
    - zlib 1.2.11 (source)
    - curl 7.74.0 & 7.76.1 (source)
    - libzip 1.7.3 (source)
  - Linux:
    - Kernel 5.8.0-50-generic
    - Ubuntu 20.04.0
    - gcc 9.3.0 (apt: gcc)
    - CMake 3.16.3 (apt: cmake)
    - zlib 1.2.11 (apt: zlib1g-dev)
    - curl 7.68.0 (apt: libcurl4-openssl-dev), 7.74.0 & 7.76.1 (source)
    - libzip 1.5.1 (apt: libzip-dev)
