### PR TITLE
Fix the incomplete error message "Couldn't open file ..." when patching files

### DIFF
--- a/src/patchutils.cpp
+++ b/src/patchutils.cpp
@@ -175,7 +175,7 @@ void Patcher::patchSMC(fs::path name, bool isSharedObj)
 {
 	std::fstream i_file(name, std::ios_base::binary | std::ios_base::out | std::ios_base::in);
 	if (!i_file.good())
-		throw PatchException("Couldn't open file %s", name.c_str());
+		throw PatchException("Couldn't open file %s", name.string().c_str());
 
 	long smc_old_memptr = 0;
 	long smc_new_memptr = 0;
@@ -415,7 +415,7 @@ void Patcher::patchBase(fs::path name)
 	logd("GOS Patching: " + name.filename().string());
 	std::fstream file(name, std::ios_base::binary | std::ios_base::in | std::ios_base::out);
 	if (!file.good())
-		throw PatchException("Couldn't open file %s", name.c_str());
+		throw PatchException("Couldn't open file %s", name.string().c_str());
 
 	// Entry to search for in GOS table
 	// Should work for Workstation 12 - 15...


### PR DESCRIPTION
I'm going to make the error message more meaningful.

I don't know why `std::filesystem::path::c_str()` does not work on Windows. Sad.

Comparison:

```diff
  File: vmwarebase.dll
  GOS Patching: vmwarebase.dll
- Couldn't open file C
+ Couldn't open file C:\Program Files (x86)\VMware\VMware Workstation\vmwarebase.dll
```

Related issues: #3 , https://github.com/paolo-projects/auto-unlocker/issues/9#issuecomment-594154075 (expand "auto-unlocker v.1.1") , #60 & #63

---

## Test

<details>

<summary>See the output of <code>std::filesystem::path::c_str()</code></summary>

### Source code

```cpp
#include <string>
#include <iostream>
#include <filesystem>

void testPath(const std::string &path_s)
{
    std::cerr << "> Orig: " << path_s << std::endl;

    std::filesystem::path path{path_s};

    std::cerr <<    "path.c_str()          = " << path.c_str()          << std::endl;
    std::cerr <<    "path.string()         = " << path.string()         << std::endl;
    std::cerr <<    "path.string().c_str() = " << path.string().c_str() << std::endl;

    fprintf(stderr, "Couldn't open file      %s\n", path         .c_str());
    fprintf(stderr, "Couldn't open file      %s\n", path.string().c_str());
}

int main(int argc, char *argv[])
{
    // Windows style
    testPath(std::string{ "C:\\d\\E.f" });
    testPath(std::string{   "\\d\\E.f" });
    testPath(std::string{     "d\\E.f" });

    // Unix style
    testPath(std::string{ "/C/d/E.f" });
    testPath(std::string{  "C/d/E.f" });
    testPath(std::string{    "d/E.f" });

    return 0;
}

```

### Test on Linux

Ubuntu 20.04.3 (g++ 9.3.0).

```console
> Orig: C:\d\E.f
path.c_str()          = C:\d\E.f
path.string()         = C:\d\E.f
path.string().c_str() = C:\d\E.f
Couldn't open file      C:\d\E.f
Couldn't open file      C:\d\E.f
> Orig: \d\E.f
path.c_str()          = \d\E.f
path.string()         = \d\E.f
path.string().c_str() = \d\E.f
Couldn't open file      \d\E.f
Couldn't open file      \d\E.f
> Orig: d\E.f
path.c_str()          = d\E.f
path.string()         = d\E.f
path.string().c_str() = d\E.f
Couldn't open file      d\E.f
Couldn't open file      d\E.f
> Orig: /C/d/E.f
path.c_str()          = /C/d/E.f
path.string()         = /C/d/E.f
path.string().c_str() = /C/d/E.f
Couldn't open file      /C/d/E.f
Couldn't open file      /C/d/E.f
> Orig: C/d/E.f
path.c_str()          = C/d/E.f
path.string()         = C/d/E.f
path.string().c_str() = C/d/E.f
Couldn't open file      C/d/E.f
Couldn't open file      C/d/E.f
> Orig: d/E.f
path.c_str()          = d/E.f
path.string()         = d/E.f
path.string().c_str() = d/E.f
Couldn't open file      d/E.f
Couldn't open file      d/E.f

```

### Test on Windows

Windows 11 10.0.22000.434 (MSVC v143 cl 19.30.30709 & MINGW-W64 g++ 11.2.0).

```console
> Orig: C:\d\E.f
path.c_str()          = 0000016EA02DC120
path.string()         = C:\d\E.f
path.string().c_str() = C:\d\E.f
Couldn't open file      C
Couldn't open file      C:\d\E.f
> Orig: \d\E.f
path.c_str()          = 0000002B7AEFF5E0
path.string()         = \d\E.f
path.string().c_str() = \d\E.f
Couldn't open file      \
Couldn't open file      \d\E.f
> Orig: d\E.f
path.c_str()          = 0000002B7AEFF5E0
path.string()         = d\E.f
path.string().c_str() = d\E.f
Couldn't open file      d
Couldn't open file      d\E.f
> Orig: /C/d/E.f
path.c_str()          = 0000016EA02DB940
path.string()         = /C/d/E.f
path.string().c_str() = /C/d/E.f
Couldn't open file      /
Couldn't open file      /C/d/E.f
> Orig: C/d/E.f
path.c_str()          = 0000002B7AEFF5E0
path.string()         = C/d/E.f
path.string().c_str() = C/d/E.f
Couldn't open file      C
Couldn't open file      C/d/E.f
> Orig: d/E.f
path.c_str()          = 0000002B7AEFF5E0
path.string()         = d/E.f
path.string().c_str() = d/E.f
Couldn't open file      d
Couldn't open file      d/E.f

```

</details>
