### PR TITLE
fix: winservices.cpp is useless in archive tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -173,7 +173,6 @@ set (TESTTAR_SOURCES tests/test_tar.cpp /
 				src/buildsparser.cpp /
 				src/archive.cpp /
 				src/installinfo.cpp /
-				src/winservices.cpp /
 				src/network.cpp /
 				src/tar.cpp /
 				src/ziparchive.cpp)
@@ -207,7 +206,6 @@ set (TESTZIP_SOURCES tests/test_zip.cpp /
 				src/buildsparser.cpp /
 				src/archive.cpp /
 				src/installinfo.cpp /
-				src/winservices.cpp /
 				src/network.cpp /
 				src/tar.cpp /
 				src/ziparchive.cpp /


### PR DESCRIPTION
Hi.

Error on Ubuntu:

```console
$ make
Scanning dependencies of target TestTar
[  2%] Building CXX object CMakeFiles/TestTar.dir/tests/test_tar.cpp.o
[  4%] Building CXX object CMakeFiles/TestTar.dir/src/debug.cpp.o
[  6%] Building CXX object CMakeFiles/TestTar.dir/src/patcher.cpp.o
[  9%] Building CXX object CMakeFiles/TestTar.dir/src/versionparser.cpp.o
[ 11%] Building CXX object CMakeFiles/TestTar.dir/src/buildsparser.cpp.o
[ 13%] Building CXX object CMakeFiles/TestTar.dir/src/archive.cpp.o
[ 16%] Building CXX object CMakeFiles/TestTar.dir/src/installinfo.cpp.o
[ 18%] Building CXX object CMakeFiles/TestTar.dir/src/winservices.cpp.o
In file included from .../auto-unlocker/src/winservices.cpp:1:
.../auto-unlocker/include/winservices.h:7:10: fatal error: Windows.h: No such file or directory
    7 | #include "Windows.h"
      |          ^~~~~~~~~~~
compilation terminated.
make[2]: *** [CMakeFiles/TestTar.dir/build.make:154: CMakeFiles/TestTar.dir/src/winservices.cpp.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:80: CMakeFiles/TestTar.dir/all] Error 2
make: *** [Makefile:95: all] Error 2

```

I didn't see any reason why "winservices.cpp" should be built in the zip and tar tests, so I removed it.