### PR TITLE
Limit vmware tools version to <= 13.5.2

### DIFF
--- a/include/config.h
+++ b/include/config.h
@@ -38,6 +38,9 @@
 // Base URL to parse for the tools
 #define FUSION_BASE_URL "http://softwareupdate.vmware.com/cds/vmw-desktop/fusion/"
 
+// Last version with OSX tools
+#define FUSION_LAST_WORKING_VERSION "13.5.2"
+
 // Relative URLs and file names to be appended to version/build numbers
 #define FUSION_DEF_CORE_LOC "/universal/core/com.vmware.fusion.zip.tar"
 #define FUSION_DEF_CORE_NAME "com.vmware.fusion.zip.tar"

--- a/src/versionparser.cpp
+++ b/src/versionparser.cpp
@@ -5,6 +5,8 @@ VersionParser::VersionParser(const std::string& versionhtmltext)
 {
 	std::istringstream iss(htmltext);
 
+	Version lastworkingversion(FUSION_LAST_WORKING_VERSION);
+
 	std::string line;
 	while (std::getline(iss, line))
 	{
@@ -14,7 +16,8 @@ VersionParser::VersionParser(const std::string& versionhtmltext)
 			if (std::regex_match(line, vmatch, pattern))
 			{
 				Version v(vmatch.str(1));
-				versions.emplace_back(v);
+				if (v <= lastworkingversion)
+					versions.emplace_back(v);
 			}
 		}
 		catch (const Version::VersionException & exc)


### PR DESCRIPTION
This is last version with OSX tools.